### PR TITLE
Add support for flipped tiles (Godot 4.2)

### DIFF
--- a/addons/amano-ldtk-importer/src/ldtk-layer.gd
+++ b/addons/amano-ldtk-importer/src/ldtk-layer.gd
@@ -147,7 +147,10 @@ static func create_tile_layer(
 			Vector2i(tileset_source.texture_region_size),
 			Vector2i.ZERO
 		)
-		tilemap.set_cell(layer_index, cell_grid_coords, tileset_source_id, tile_grid_coords)
+		var flipx = int(tile.f) & 1
+		var flipy = int(tile.f) & 2
+		var flip_bits = (TileSetAtlasSource.TRANSFORM_FLIP_H if flipx != 0 else 0) | (TileSetAtlasSource.TRANSFORM_FLIP_V if flipy != 0 else 0)
+		tilemap.set_cell(layer_index, cell_grid_coords, tileset_source_id, tile_grid_coords, flip_bits)
 
 	return true
 


### PR DESCRIPTION
[Godot 4.2](https://godotengine.org/article/godot-4-2-arrives-in-style/) arrived adding the support for flipping tiles.

Not much to say, just converting LDTk's flipping bits to the brand new godot's tilemap tile flipping system